### PR TITLE
Change MySQL RDS database name

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,7 +25,7 @@ variable "db_subnet_cidrs" {
 
 variable "db_name" {
   description = "Name of the MySQL RDS instance"
-  default     = "wp-db"
+  default     = "wp_db"
 }
 
 variable "db_username" {


### PR DESCRIPTION
The MySQL name cannot contain hyphens.
Changed the hyphen in the name to an underscore.