### PR TITLE
Provision LB in front of the two web servers

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -79,43 +79,19 @@ resource "aws_security_group" "lb_sg" {
   tags = local.tags
 }
 
-data "aws_availability_zone" "az" {
+data "aws_availability_zones" "subnet_az" {
   filter {
     name   = "zone-id"
     values = aws_subnet.public[*].availability_zone_id
   }
 }
 
-resource "aws_elb" "elb" {
-  name               = "wordpress-load-balancer"
-  availability_zones = data.aws_availability_zone.az[*].name
-  security_groups    = [aws_security_group.lb_sg.id]
-  internal           = false
-
-  access_logs {
-    bucket        = "825144470306-terraform-state"
-    bucket_prefix = "wordpress/elb"
-  }
-
-  listener {
-    instance_port     = 80
-    instance_protocol = "http"
-    lb_port           = 80
-    lb_protocol       = "http"
-  }
-
-  health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    timeout             = 3
-    target              = "HTTP:80/"
-    interval            = 30
-  }
-
-  instances                   = aws_instance.web_server[*].id
-  idle_timeout                = 400
-  connection_draining         = true
-  connection_draining_timeout = 400
+resource "aws_lb" "lb" {
+  name            = "wordpress-load-balancer"
+  subnets         = aws_subnet.public[*].id
+  security_groups = [aws_security_group.lb_sg.id]
+  internal        = false
 
   tags = local.tags
 }
+

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -79,9 +79,16 @@ resource "aws_security_group" "lb_sg" {
   tags = local.tags
 }
 
+data "aws_availability_zone" "az" {
+  filter {
+    name   = "zone-id"
+    values = aws_subnet.public[*].availability_zone_id
+  }
+}
+
 resource "aws_elb" "elb" {
   name               = "wordpress-load-balancer"
-  availability_zones = aws_subnet.public[*].availability_zone_id
+  availability_zones = data.aws_availability_zone.az[*].name
   security_groups    = [aws_security_group.lb_sg.id]
   internal           = false
 

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -15,12 +15,6 @@ resource "aws_security_group" "web_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  ingress {
-    from_port   = 8000
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
   egress {
     from_port        = 0
     to_port          = 0
@@ -82,13 +76,6 @@ resource "aws_security_group" "lb_sg" {
     security_groups = [aws_security_group.web_sg.id]
   }
 
-  egress {
-    from_port       = 8000
-    to_port         = 8000
-    protocol        = "tcp"
-    security_groups = [aws_security_group.web_sg.id]
-  }
-
   tags = local.tags
 }
 
@@ -114,7 +101,7 @@ resource "aws_elb" "elb" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:8000/"
+    target              = "HTTP:80/"
     interval            = 30
   }
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -37,4 +37,5 @@ resource "aws_db_instance" "rds" {
   username               = var.db_username
   password               = var.db_password
   vpc_security_group_ids = [aws_security_group.db_sg.id]
+  skip_final_snapshot    = true
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -6,10 +6,15 @@ resource "aws_vpc" "vpc" {
   tags = merge(local.tags, { "Name" = "wordpress-vpc" })
 }
 
+data "aws_availability_zones" "az" {
+  state = "available"
+}
+
 resource "aws_subnet" "private" {
-  count      = length(var.private_subnet_cidrs)
-  vpc_id     = aws_vpc.vpc.id
-  cidr_block = var.private_subnet_cidrs[count.index]
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = data.aws_availability_zones.az.names[count.index]
 
   tags = merge(local.tags, { "Name" = "wordpress-private-subnet-${count.index}" })
 }
@@ -28,9 +33,10 @@ resource "aws_subnet" "public" {
 }
 
 resource "aws_subnet" "db" {
-  count      = length(var.db_subnet_cidrs)
-  vpc_id     = aws_vpc.vpc.id
-  cidr_block = var.db_subnet_cidrs[count.index]
+  count             = length(var.db_subnet_cidrs)
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = var.db_subnet_cidrs[count.index]
+  availability_zone = data.aws_availability_zones.az.names[count.index]
 
   tags = merge(local.tags, { "Name" = "wordpress-db-subnet-${count.index}" })
 }


### PR DESCRIPTION
Configure an ELB that routes the traffic to the 2 private wordpress web
servers.
Also provisioned a security group linked to the ELB that permits
internet traffic to the ELB and outbound traffic to the web servers.
Changed the SG rules for the web server SG to accommodate the load
balancer rules.